### PR TITLE
Add iafTauRefCell and iafRefCell to schema and examples.

### DIFF
--- a/NeuroML2CoreTypes/LEMS_NML2_Ex0_IaF.xml
+++ b/NeuroML2CoreTypes/LEMS_NML2_Ex0_IaF.xml
@@ -22,18 +22,25 @@
 
 
     <!-- Main NeuroML2 content -->
-
     <iafTauCell id="iafTau" leakReversal="-50mV" thresh="-55mV"
         reset="-70mV" tau="30ms" />
+    <iafTauRefCell id="iafTauRef" leakReversal="-50mV" thresh="-55mV"
+        reset="-70mV" tau="30ms" refract="5ms"/>
     <iafCell id="iaf" leakConductance="0.2nS" leakReversal="-53mV"
 	     thresh="-55mV" reset="-70mV" C="3.2pF"/>
     <iafRefCell id="iafRef" leakConductance="0.2nS" leakReversal="-53mV"
-		thresh="-55mV" reset="-70mV" C="3.2pF" refract="2ms"/>
+		thresh="-55mV" reset="-70mV" C="3.2pF" refract="5ms"/>
+    <adExIaFCell id="adExBurst" C="3.2pF" gL="2nS" EL="-53mV"
+		 reset="-70mV" VT="-50.4mV" thresh ="-55mV"
+		 refract="0ms" delT="2mV" tauw="40ms" a="4nS"
+		 b="0.08nA"/>
 
     <network id="net1">
         <population id="iafTauPop" component="iafTau" size="1" />
+        <population id="iafTauRefPop" component="iafTauRef" size="1" />
 	<population id="iafPop" component="iaf" size="1" />
 	<population id="iafRefPop" component="iafRef" size="1" />
+	<population id="adExBurstPop" component="adExBurst" size="1"/>
     </network>
 
     <!-- End of NeuroML2 content -->
@@ -41,10 +48,19 @@
 
     <Simulation id="sim1" length="300ms" step="0.01ms" target="net1">
 
-        <Display id="d0" title="Ex0: Simple Integrate and Fire cells in LEMS" timeScale="1ms" xmin="0" xmax="300" ymin="-75" ymax="-50">
-            <Line id="iafTauCell" quantity="iafTauPop[0]/v" scale="1mV" color="#000000" timeScale="1ms" />
-	    <Line id="iafCell" quantity="iafPop[0]/v" scale="1mV" color="#3ADF00" timeScale="1ms" />
-	    <Line id="iafRefCell" quantity="iafRefPop[0]/v" scale="1mV" color="#0000FF" timeScale="1ms" />
+        <Display id="d0" title="Ex0: Simple Integrate and Fire cells
+				in LEMS" timeScale="1ms" xmin="0"
+		 xmax="300" ymin="-75" ymax="-50">
+            <Line id="iafTauCell" quantity="iafTauPop[0]/v"
+		  scale="1mV" color="#FF0000" timeScale="1ms" />
+            <Line id="iafTauRefCell" quantity="iafTauRefPop[0]/v"
+		  scale="1mV" color="#D7DF01" timeScale="1ms" />
+	    <Line id="iafCell" quantity="iafPop[0]/v" scale="1mV"
+		  color="#01DF3A" timeScale="1ms" />
+	    <Line id="iafRefCell" quantity="iafRefPop[0]/v"
+		  scale="1mV" color="#0174DF" timeScale="1ms" />
+	    <Line id="adExBurstCell" quantity="adExBurstPop[0]/v"
+		  scale="1mV" color="#B40486" timeScale="1ms"/>
         </Display>
 
         <OutputFile id="of0" fileName="results/iaf_v.dat">

--- a/Schemas/NeuroML2/NeuroML_v2beta.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2beta.xsd
@@ -278,7 +278,7 @@
 
     </xs:complexType>
 
-    <!-- A small subset of XLInclude from: http://www.w3.org/2001/XInclude.xsd  
+    <!-- A small subset of XLInclude from: http://www.w3.org/2001/XInclude.xsd
          Will be sufficient for now... -->
     <xs:complexType name="IncludeType" mixed="true">
         <xs:attribute name="href" use="optional" type="xs:anyURI"/>
@@ -291,14 +291,20 @@
         <xs:sequence>
             <xs:element name="cell" type="Cell" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="baseCell" type="BaseCell" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="iafTauCell" type="IaFTauCell" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="iafCell" type="IaFCell" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="iafTauCell" type="IaFTauCell"
+			minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="iafTauRefCell" type="IaFTauRefCell"
+			minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="iafCell" type="IaFCell" minOccurs="0"
+			maxOccurs="unbounded"/>
+            <xs:element name="iafRefCell" type="IaFRefCell" minOccurs="0"
+			maxOccurs="unbounded"/>
             <xs:element name="izhikevichCell" type="IzhikevichCell" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="adExIaFCell" type="AdExIaFCell" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:group>
-    
-    
+
+
     <xs:group name="PyNNCellTypes">
         <xs:annotation>
             <xs:documentation>Various types of cells which are defined in NeuroML 2 based on PyNN standard cell models. </xs:documentation>
@@ -666,6 +672,14 @@
         </xs:complexContent>
     </xs:complexType>
 
+    <xs:complexType name="IaFTauRefCell">
+      <xs:complexContent>
+	<xs:extension base="IaFTauCell">
+	  <xs:attribute name="refract" type="Nml2Quantity_time" use="required"/>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="IaFCell">
         <xs:complexContent>
             <xs:extension base="BaseCell">
@@ -676,6 +690,14 @@
                 <xs:attribute name="leakConductance" type="Nml2Quantity_conductance" use="required"/>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="IaFRefCell">
+      <xs:complexContent>
+	<xs:extension base="IaFCell">
+	  <xs:attribute name="refract" type="Nml2Quantity_time" use="required"/>
+	</xs:extension>
+      </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="IzhikevichCell">
@@ -983,7 +1005,7 @@
                     <xs:annotation>
                         <xs:documentation>Specifying the ion here again is redundant, this will be set in ionChannel. It is added here
                         TEMPORARILY as selecting all ca or na conducting channel populations/densities in a cell would be difficult otherwise.
-                        It should be removed in the longer term, due to possible inconsistencies in this value and that in the ionChannel 
+                        It should be removed in the longer term, due to possible inconsistencies in this value and that in the ionChannel
                         element. TODO: remove.
                         </xs:documentation>
                     </xs:annotation>
@@ -1635,6 +1657,3 @@
     </xs:complexType>
 
 </xs:schema>
-
-
-

--- a/examples/NML2_AbstractCells.nml
+++ b/examples/NML2_AbstractCells.nml
@@ -7,14 +7,24 @@
 
     <!-- Instances of some of the abstract cell types currently supported in NeuroML 2. -->
 
-    <iafTauCell id="iafTau" leakReversal="-50mV" thresh="-55mV" reset="-70mV" tau="30ms"/>
+    <iafTauCell id="iafTau" leakReversal="-50mV" thresh="-55mV"
+		reset="-70mV" tau="30ms"/>
 
-    <iafCell id="iafCell" leakReversal="-50mV" thresh="-55mV" reset="-70mV" C="0.2nF" leakConductance="0.01uS"/>
+    <iafTauRefCell id="iafTauRef" leakReversal="-50mV" thresh="-55mV"
+		   reset="-70mV" tau="30ms" refract="5ms"/>
 
-    <izhikevichCell id="izBurst" v0 = "-70mV" thresh = "30mV" a ="0.02" b = "0.2" c = "-50.0" d = "2"/>
+    <iafCell id="iaf" leakReversal="-50mV" thresh="-55mV"
+	     reset="-70mV" C="0.2nF" leakConductance="0.01uS"/>
 
-    <adExIaFCell id="adExBurst" C="281pF" gL="30nS" EL="-70.6mV" reset="-48.5mV" VT = "-50.4mV" thresh = "-40.4mV"
-                 refract="0ms" delT="2mV" tauw="40ms"  a ="4nS"   b = "0.08nA"/>
+    <iafRefCell id="iafRef" leakReversal="-50mV" thresh="-55mV"
+		reset="-70mV" C="0.2nF" leakConductance="0.01uS" refract="5ms"/>
 
+    <izhikevichCell id="izBurst" v0 = "-70mV" thresh = "30mV" a="0.02"
+		    b = "0.2" c = "-50.0" d = "2"/>
+
+    <adExIaFCell id="adExBurst" C="281pF" gL="30nS" EL="-70.6mV"
+		 reset="-48.5mV" VT = "-50.4mV" thresh="-40.4mV"
+		 refract="0ms" delT="2mV" tauw="40ms" a="4nS"
+		 b="0.08nA"/>
 
 </neuroml>


### PR DESCRIPTION
These cell types are already present in the core component type
definitions, but they were not represented in the schema and in the
examples.
