### PR TITLE
Add Inputs.xml definitions to schema and examples.

### DIFF
--- a/NeuroML2CoreTypes/LEMS_NML2_Ex16_Inputs.xml
+++ b/NeuroML2CoreTypes/LEMS_NML2_Ex16_Inputs.xml
@@ -19,8 +19,13 @@
 
 
 
-<adExIaFCell id="adExBurst4"  C="281pF" gL="30nS" EL="-70.6mV" reset="-47.2mV" VT = "-50.4mV" thresh = "-40.4mV" delT="2mV" tauw="40ms"  a ="4nS"   b = "0.08nA"
-                refract="0ms" Iamp="0.0nA" Idel="0ms" Idur="2000ms"/>
+<adExIaFCell id="adExBurst4"  C="281pF" gL="10nS" EL="-70.6mV"
+	     reset="-47.2mV" VT = "-50.4mV" thresh = "-40.4mV"
+	     delT="2mV" tauw="40ms"  a ="4nS"   b = "0.08nA"
+	     refract="0ms" Iamp="0.0nA" Idel="0ms" Idur="2000ms"/>
+
+<expTwoSynapse id="syn1" gbase="1nS" erev="20mV" tauRise="0.1ms"
+	       tauDecay="5ms"/>
 
 
 <pulseGenerator id="pulseGen0" delay="50ms" duration="200ms" amplitude="0.8 nA" />
@@ -29,14 +34,43 @@
 
 <rampGenerator id="rg0" delay="50ms" duration="200ms" startAmplitude="0.5nA" finishAmplitude="2nA" baselineAmplitude="0nA"/>
 
-<voltageClamp id="vClamp0" delay="50ms" duration="200ms" targetVoltage="-50mV" seriesResistance="10ohm"/>
+<voltageClamp id="vClamp0" delay="50ms" duration="200ms"
+	      targetVoltage="-50mV" seriesResistance="10ohm"/>
+
+<spikeArray id="spkArr">
+  <spike id="0" time="100 ms"/>
+  <spike id="1" time="130 ms"/>
+</spikeArray>
+
+<spikeGenerator id="spikeGen" period="20 ms"/>
+
+<spikeGeneratorRandom id="spikeGenRandom" minISI="10 ms"
+		      maxISI="30 ms"/>
+
+<spikeGeneratorPoisson id="spikeGenPoisson" averageRate="50 Hz"/>
 
 <network id="net1">
-    <population id="adExPop" component="adExBurst4" size="4"/>
+    <population id="adExPop" component="adExBurst4" size="8"/>
+
+    <population id="spikeArrPop" component="spkArr" size="1"/>
+    <population id="spikeGenPop" component="spikeGen" size="1"/>
+    <population id="spikeGenRandomPop"
+		component="spikeGenRandom" size="1"/>
+    <population id="spikeGenPoissonPop"
+		component="spikeGenPoisson" size="1"/>
+
     <explicitInput target="adExPop[0]" input="pulseGen0"/>
     <explicitInput target="adExPop[1]" input="sg0"/>
     <explicitInput target="adExPop[2]" input="rg0"/>
     <explicitInput target="adExPop[3]" input="vClamp0"/>
+    <synapticConnection from="spikeArrPop[0]" to="adExPop[4]"
+			synapse="syn1"/>
+    <synapticConnection from="spikeGenPop[0]" to="adExPop[5]"
+			synapse="syn1"/>
+    <synapticConnection from="spikeGenRandomPop[0]" to="adExPop[6]"
+			synapse="syn1"/>
+    <synapticConnection from="spikeGenPoissonPop[0]" to="adExPop[7]"
+			synapse="syn1"/>
 </network>
 
         <!-- End of NeuroML2 content -->
@@ -44,7 +78,7 @@
 
 <Simulation id="sim1" length="300ms" step="0.05ms" target="net1">
 
-    <Display id="d0" title="Ex16: Adaptive exponential cell, curent clamp input" timeScale="1ms" xmin="0" xmax="300" ymin="-80" ymax="20">
+    <Display id="d0" title="Ex16: Adaptive exponential cell, current clamp input" timeScale="1ms" xmin="0" xmax="300" ymin="-80" ymax="20">
         <Line id ="adEx0" quantity="adExPop[0]/v" scale="1mV"  color="#ee40FF" timeScale="1ms"/>
         <Line id ="adEx0i" quantity="adExPop[0]/pulseGen0/i" scale="0.1nA"  color="#333333" timeScale="1ms"/>
     </Display>
@@ -59,6 +93,18 @@
     <Display id="d3" title="Ex16: Adaptive exponential cell, voltage clamp" timeScale="1ms" xmin="0" xmax="300" ymin="-110" ymax="35">
         <Line id ="adEx3" quantity="adExPop[3]/v" scale="1mV"  color="#ee40FF" timeScale="1ms"/>
         <Line id ="adEx3i" quantity="adExPop[3]/vClamp0/i" scale="0.1nA"  color="#333333" timeScale="1ms"/>
+    </Display>
+    <Display id="d4" title="Ex16: Adaptive exponential cell, spiking
+			    inputs" timeScale="1ms" xmin="0"
+	     xmax="300" ymin="-74" ymax="-65">
+      <Line id="spike array" quantity="adExPop[4]/v" scale="1mV"
+	    color="#DBA901" timeScale="1ms"/>
+      <Line id="regular spike gen" quantity="adExPop[5]/v" scale="1mV"
+	    color="#80FF00" timeScale="1ms"/>
+      <Line id="random (uniform) spike gen" quantity="adExPop[6]/v" scale="1mV"
+	    color="#01A9DB" timeScale="1ms"/>
+      <Line id="poisson spike gen" quantity="adExPop[7]/v" scale="1mV"
+	    color="#8000FF" timeScale="1ms"/>
     </Display>
     
 </Simulation>

--- a/Schemas/NeuroML2/NeuroML_v2beta.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2beta.xsd
@@ -59,6 +59,14 @@
 
     </xs:simpleType>
 
+    <xs:simpleType name="Nml2Quantity_resistance">
+
+        <xs:restriction base="xs:string">
+            <xs:pattern value="-?([0-9]*(\.[0-9]+)?)([eE]-?[0-9]+)?[\s]*(ohm|Kohm|Mohm)"/> <!-- Based on set of defined Units in NeuroMLCoreDimensions.xml -->
+        </xs:restriction>
+
+    </xs:simpleType>
+
     <xs:simpleType name="Nml2Quantity_conductance">
 
         <xs:restriction base="xs:string">
@@ -257,14 +265,14 @@
                     <xs:element name="biophysicalProperties" type="BiophysicalProperties" minOccurs="0" maxOccurs="unbounded"/>
 
                     <xs:group ref="CellTypes"/>
+
+		    <xs:group ref="InputTypes"/>
                     
                     <xs:group ref="PyNNCellTypes"/>
                     
                     <xs:group ref="PyNNSynapseTypes"/>
                     
                     <xs:group ref="PyNNInputTypes"/>
-
-                    <xs:element name="pulseGenerator" type="PulseGenerator" minOccurs="0" maxOccurs="unbounded"/>
 
                     <xs:element name="network" type="Network" minOccurs="0" maxOccurs="unbounded"/>
 
@@ -347,6 +355,32 @@
         </xs:sequence>
     </xs:group>
     
+    <xs:group name="InputTypes">
+      <xs:annotation>
+	<xs:documentation>
+	  Various types of inputs which are defined in NeuroML2. This
+	  list will be expanded...
+	</xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+	<xs:element name="pulseGenerator" type="PulseGenerator"
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="sineGenerator" type="SineGenerator"
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="rampGenerator" type="RampGenerator"
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="voltageClamp" type="VoltageClamp"
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="spikeArray" type="SpikeArray" minOccurs="0"
+		    maxOccurs="unbounded"/>
+	<xs:element name="spikeGenerator" type="SpikeGenerator" 
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="spikeGeneratorRandom" type="SpikeGeneratorRandom"
+		    minOccurs="0" maxOccurs="unbounded"/>
+	<xs:element name="spikeGeneratorPoisson" type="SpikeGeneratorPoisson" 
+		    minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+    </xs:group>
     
     <xs:group name="PyNNInputTypes">
         <xs:annotation>
@@ -1158,17 +1192,124 @@
 <!--Will be updated in line with LEMS ComponentType definitions -->
 
     <xs:complexType name="PulseGenerator">
-
         <xs:complexContent>
             <xs:extension base="Standalone">
-
-                <xs:attribute name="delay" type="Nml2Quantity_time" use="required"/>
-                <xs:attribute name="duration" type="Nml2Quantity_time" use="required"/>
-                <xs:attribute name="amplitude" type="Nml2Quantity_current" use="required"/>
-
+              <xs:attribute name="delay" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="duration" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="amplitude"
+			    type="Nml2Quantity_current"
+			    use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+
+    <xs:complexType name="SineGenerator">
+        <xs:complexContent>
+            <xs:extension base="Standalone">
+              <xs:attribute name="delay" type="Nml2Quantity_time"
+			    use="required"/>
+	      <xs:attribute name="phase" type="Nml2Quantity_none"
+			    use="required"/>
+              <xs:attribute name="duration" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="amplitude"
+			    type="Nml2Quantity_current"
+			    use="required"/>
+	      <xs:attribute name="period" type="Nml2Quantity_time"
+			    use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="RampGenerator">
+        <xs:complexContent>
+            <xs:extension base="Standalone">
+              <xs:attribute name="delay" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="duration" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="startAmplitude"
+			    type="Nml2Quantity_current"
+			    use="required"/>
+              <xs:attribute name="finishAmplitude"
+			    type="Nml2Quantity_current"
+			    use="required"/>
+              <xs:attribute name="baselineAmplitude"
+			    type="Nml2Quantity_current"
+			    use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="VoltageClamp">
+        <xs:complexContent>
+            <xs:extension base="Standalone">
+              <xs:attribute name="delay" type="Nml2Quantity_time"
+			    use="required"/>
+              <xs:attribute name="duration" type="Nml2Quantity_time"
+			    use="required"/>
+	      <xs:attribute name="targetVoltage"
+			    type="Nml2Quantity_voltage"
+			    use="required"/>
+	      <xs:attribute name="seriesResistance"
+			    type="Nml2Quantity_resistance"
+			    use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="Spike">
+      <xs:complexContent>
+	<xs:extension base="Standalone">
+	  <xs:attribute name="time" type="Nml2Quantity_time"
+			use="required"/>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="SpikeArray">
+      <xs:complexContent>
+	<xs:extension base="Standalone">
+          <xs:sequence>
+            <xs:element name="spike" type="Spike" minOccurs="0"
+			maxOccurs="unbounded"/>
+	  </xs:sequence>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="SpikeGenerator">
+      <xs:complexContent>
+	<xs:extension base="Standalone">
+	  <xs:attribute name="period" type="Nml2Quantity_time"
+			use="required"/>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="SpikeGeneratorRandom">
+      <xs:complexContent>
+	<xs:extension base="Standalone">
+	  <xs:attribute name="maxISI" type="Nml2Quantity_time"
+			use="required"/>
+	  <xs:attribute name="minISI" type="Nml2Quantity_time"
+			use="required"/>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="SpikeGeneratorPoisson">
+      <xs:complexContent>
+	<xs:extension base="Standalone">
+	  <xs:attribute name="averageRate" type="Nml2Quantity_pertime"
+			use="required"/>
+	</xs:extension>
+      </xs:complexContent>
+    </xs:complexType>
+
+
 
     <!--+++++++++++++++++++++++++++++++++++++++++++++++++++++++-->
     <!--      Networks                                         -->

--- a/examples/NML2_Inputs.nml
+++ b/examples/NML2_Inputs.nml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<neuroml xmlns="http://www.neuroml.org/schema/neuroml2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.neuroml.org/schema/neuroml2  ../Schemas/NeuroML2/NeuroML_v2beta.xsd"
+    id="NML2_Inputs">
+
+    <!-- Some examples of the currently supported input types -->
+
+    <pulseGenerator id="pulseGen" delay="10 ms" duration="100 ms"
+		    amplitude="50 pA"/>
+
+    <sineGenerator id="sineGen" phase="0" delay="50ms"
+		   duration="200ms" amplitude="1.2nA" period="50ms"/>
+
+    <rampGenerator id="rampGen" delay="50ms" duration="200ms"
+		   startAmplitude="0.5nA" finishAmplitude="2nA"
+		   baselineAmplitude="0nA"/>
+
+    <voltageClamp id="vClamp" delay="50ms" duration="200ms"
+		  targetVoltage="-50mV" seriesResistance="10ohm"/>
+
+    <spikeArray id="spkArr">
+      <spike id="0" time="20 ms"/>
+      <spike id="1" time="30 ms"/>
+    </spikeArray>
+
+    <spikeGenerator id="spikeGen" period="20 ms"/>
+
+    <spikeGeneratorRandom id="spikeGenRandom" minISI="10 ms"
+			  maxISI="30 ms"/>
+
+    <spikeGeneratorPoisson id="spikeGenPoisson" averageRate="50 Hz"/>
+
+</neuroml>


### PR DESCRIPTION
Also, add simpleType for resistance to schema, and improve the
relevant LEMS simulation example.

Note that Inputs.xml is still not valid LEMS, as spikeGeneratorPoisson
uses a DerivedParameter to calculate the average ISI only once (rather
than at each timestep).
