### PR TITLE
Added FHN1969

### DIFF
--- a/NeuroML2CoreTypes/Cells.xml
+++ b/NeuroML2CoreTypes/Cells.xml
@@ -1129,6 +1129,46 @@
 
     </ComponentType>
 
+    <ComponentType  name="fitzHughNagumo1969Cell"
+                    extends="baseCellMembPotDL"
+                    description=" The Fitzhugh Nagumo model is a two-dimensional simplification of the Hodgkin-Huxley model of spike generation in squid giant axons.  This system was suggested by FitzHugh (FitzHugh R. [1961]: Impulses and physiological states in theoretical models of nerve membrane.  Biophysical J.  1:445-466), who called it &quot; Bonhoeffer-van der Pol model &quot;, and the equivalent circuit by Nagumo et al.  (Nagumo J., Arimoto S., and Yoshizawa S. [1962] An active pulse transmission line simulating nerve axon. Proc IRE. 50:2061–2070.1962). This version corresponds to the one described in FitzHugh R.[1969]: Mathematical models of excitation and propagation in nerve.  Chapter 1 (pp. 1–85 in H.P. Schwan, ed.  Biological Engineering, McGraw–Hill Book Co., N.Y.)">
+        
+        <Parameter name="a" dimension="none"/>
+        <Parameter name="b" dimension="none"/>
+        <Parameter name="I" dimension="none" description="plays the role of an external injected current"/>
+        <Parameter name="phi" dimension="none"/>
+    
+        <!-- Initial Conditions -->
+        <Parameter name="v0" dimension="none"/>
+        <Parameter name="w0" dimension="none"/>
+    
+        <Constant name="TS" dimension="time" value="1ms"/>
+    
+        <Exposure name="v" dimension="none"/>
+        <Exposure name="w" dimension="none"/>
+        <Exposure name="F" dimension="none"/>
+        
+        <Dynamics>
+            
+            <StateVariable name="v" dimension="none" exposure="v"
+                description="v plays the role of the membrane potential"/>
+            <StateVariable name="w" dimension="none" exposure="w"
+                description="w plays the role of a recovery variable"/>
+    
+            <DerivedVariable name="F" dimension="none" exposure="F" value="v - v^3 / 3"
+                description="F must be a cubic polynomial in v"/>
+    
+            <TimeDerivative variable="v" value="(F - w + I) / TS"/>
+            <TimeDerivative variable="w" value="phi * (v + a - b * w) / TS"/>
+            
+            <OnStart>
+                <StateAssignment variable="v" value="v0"/>
+                <StateAssignment variable="w" value="w0"/>
+            </OnStart>
+            
+        </Dynamics>
+        
+    </ComponentType>
 
     <ComponentType name="fitzHughNagumoCell"
                    extends="baseCellMembPotDL"


### PR DESCRIPTION
Initial conditions are not usually made into parameters in nml2 comptypes -- though I find it fundamental to be able to set them. This way, in this version of FHN, the pars v0, w0 are exposed as pars.