### PR TITLE
Consistent use of :,_ for rdf:x types

### DIFF
--- a/NeuroML2CoreTypes/NeuroMLCoreCompTypes.xml
+++ b/NeuroML2CoreTypes/NeuroMLCoreCompTypes.xml
@@ -100,12 +100,12 @@
     
     
     <ComponentType name="rdf_Bag" description="Work in progress...">
-        <Children name="rdf:li" type="rdf:li"/>
+        <Children name="rdf:li" type="rdf_li"/>
         <Dynamics/>
     </ComponentType>
 
 
-    <ComponentType name="rdf:li" description="Annotation...">
+    <ComponentType name="rdf_li" description="Annotation...">
         <Text name="rdf:resource"/>
         <Dynamics/>
     </ComponentType>


### PR DESCRIPTION
rdf:li was the only one which still had : instead of _
@adrianq