### PR TITLE
Subgates

### DIFF
--- a/LEMSexamples/LEMS_NML2_Ex24_FractionalConductance.xml
+++ b/LEMSexamples/LEMS_NML2_Ex24_FractionalConductance.xml
@@ -1,0 +1,210 @@
+<Lems>
+
+    <Target component="sim1"/>
+    
+    <Include file="Cells.xml"/>
+    <Include file="Networks.xml"/>
+    <Include file="Simulation.xml"/>
+
+    <!-- the slow K channel below uses the "fractional conductance / subGate" formalism -->
+    
+    <ionChannelHH id="k_slow" conductance="10pS">
+
+        <gateHHrates id="a" instances="2">
+            <q10Settings type="q10ExpTemp" q10Factor="2.3" experimentalTemp="21 degC"/> 
+            <reverseRate type="kslow_a_beta_rate"/>
+            <forwardRate  type="kslow_a_alpha_rate"/>
+        </gateHHrates>
+
+        <gateFractional id="b" instances="1">
+            <subGate fractionalConductance="0.5" id="bb" >
+                <steadyState type="HHSigmoidVariable" rate="1" midpoint="-58mV" scale="-11mV"/>
+                <timeCourse type="kslow_b_tau"/>
+            </subGate>
+            <subGate fractionalConductance="0.5" id="bb1" >
+                <steadyState type="HHSigmoidVariable" rate="1" midpoint="-58mV" scale="-11mV"/>
+                <timeCourse type="kslow_b1_tau"/>
+            </subGate>
+        </gateFractional>
+
+    </ionChannelHH>
+
+    <!-- complicated rates for kslow -->
+    <ComponentType name="kslow_a_alpha_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 ms"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 mV"/>
+        <Constant name="a0" dimension="none" value="0.0052"/>
+        <Constant name="a1" dimension="none" value="11.1"/>
+        <Constant name="a2" dimension="none" value="13.1"/>
+        <Constant name="a3" dimension="none" value="0.01938"/>
+        <Constant name="a4" dimension="none" value="-1.27"/>
+        <Constant name="a5" dimension="none" value="71"/>
+        <Constant name="a6" dimension="none" value="-0.0053"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="v / VOLT_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(a0*(V-a1)/(1-exp(-(V-a1)/a2))) / TIME_SCALE "/>
+        </Dynamics>
+
+    </ComponentType>
+
+    <ComponentType name="kslow_a_beta_rate" extends="baseVoltageDepRate">
+        <Constant name="TIME_SCALE" dimension="time" value="1 ms"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 mV"/>
+        <Constant name="a0" dimension="none" value="0.0052"/>
+        <Constant name="a1" dimension="none" value="11.1"/>
+        <Constant name="a2" dimension="none" value="13.1"/>
+        <Constant name="a3" dimension="none" value="0.01938"/>
+        <Constant name="a4" dimension="none" value="-1.27"/>
+        <Constant name="a5" dimension="none" value="71"/>
+        <Constant name="a6" dimension="none" value="-0.0053"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="v / VOLT_SCALE"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="(a3*exp(-(V-a4)/a5)+a6) / TIME_SCALE "/>
+        </Dynamics>
+
+    </ComponentType>
+
+
+    <ComponentType name="kslow_b_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 ms"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 mV"/>
+        <Constant name="v05b" dimension="none" value="-58"/>
+        <Constant name="b0" dimension="none" value="360"/>
+        <Constant name="b11" dimension="none" value="1010"/>
+        <Constant name="b2" dimension="none" value="-75"/>
+        <Constant name="b3" dimension="none" value="48"/>
+        <Constant name="b4" dimension="none" value="23.7"/>
+        <Constant name="b5" dimension="none" value="-54"/>
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="v / VOLT_SCALE"/>
+            <DerivedVariable name="t" exposure="t" dimension="time" value="(b0+(b11+b4*(V-b5))*exp(-(V-b2)*(V-b2)/(b3*b3))) * TIME_SCALE "/>
+        </Dynamics>
+
+    </ComponentType>
+
+
+    <ComponentType name="kslow_b1_tau" extends="baseVoltageDepTime">
+        <Constant name="TIME_SCALE" dimension="time" value="1 ms"/>
+        <Constant name="VOLT_SCALE" dimension="voltage" value="1 mV"/>
+        <Constant name="bb0" dimension="none" value="2350"/>
+        <Constant name="bb1" dimension="none" value="1380"/>
+        <Constant name="bb2" dimension="none" value="0.01118"/>
+        <Constant name="bb3" dimension="none" value="-210"/>
+        <Constant name="bb4" dimension="none" value="0.0306"/>
+
+
+        <Dynamics>
+            <DerivedVariable name="V" dimension="none" value="v / VOLT_SCALE"/>
+            <DerivedVariable name="t" exposure="t" dimension="time" value="(bb0+bb1*exp(-bb2*V)+bb3*exp(-bb4*V)) * TIME_SCALE "/>
+        </Dynamics>
+
+    </ComponentType>
+
+
+    <!-- just standard HH below (similar to example 1) -->
+
+    <ionChannelHH id="k" conductance="10pS">
+        <gateHHrates id="n" instances="4">
+            <forwardRate type="HHExpLinearRate" rate="0.1per_ms" midpoint="-55mV" scale="10mV"/>
+            <reverseRate type="HHExpRate" rate="0.125per_ms" midpoint="-65mV" scale="-80mV"/>
+        </gateHHrates>
+    </ionChannelHH>
+
+    <ionChannelPassive id="leak" conductance="10pS"/>
+    
+    <ionChannelHH id="na" conductance="10pS">
+    
+       <gateHHrates id="m" instances="3">
+            <forwardRate type="HHExpLinearRate" rate="1per_ms" midpoint="-40mV" scale="10mV"/>
+            <reverseRate type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
+       </gateHHrates>
+    
+       <gateHHrates id="h" instances="1">
+           <forwardRate type="HHExpRate" rate="0.07per_ms" midpoint="-65mV" scale="-20mV"/>
+           <reverseRate type="HHSigmoidRate" rate="1per_ms" midpoint="-35mV" scale="10mV"/>
+       </gateHHrates>
+    
+    </ionChannelHH>
+    
+    
+    <cell id="hh">
+        <morphology id="just_a_cylinder">
+            <segment id="0" name="Soma">
+                <proximal x="0.0" y="0.0" z="0.0" diameter="10.0"/>
+                <distal x="0.0" y="0.0" z="20.0" diameter="10.0"/>
+            </segment>
+            <segmentGroup id="all">
+                <member segment="0"/>
+            </segmentGroup>
+            <segmentGroup id="soma_group">
+                <member segment="0"/>
+            </segmentGroup>
+        </morphology>
+
+        <biophysicalProperties id="biophys">
+            <membraneProperties>
+                <channelDensity condDensity="0.12 S_per_cm2" id="naChans" ionChannel="na" erev="50.0 mV" ion="na"/> 
+                <channelDensity condDensity="0.036 S_per_cm2" id="kChans" ionChannel="k" erev="-77.0 mV" ion="k"/>
+                <channelDensity condDensity="0.036 S_per_cm2" id="k_slowChans" ionChannel="k_slow" erev="-77.0 mV" ion="k"/>
+                <channelDensity condDensity="0.0003 S_per_cm2" id="leakChans" ionChannel="leak" erev="-54.3 mV" ion="non_specific"/>
+
+                <spikeThresh value="0 mV"/>
+                <specificCapacitance value="1.0 uF_per_cm2"/>
+                <initMembPotential value="-65.0 mV"/>
+
+            </membraneProperties>
+
+
+            <intracellularProperties>
+
+                <resistivity value="0.1 kohm_cm"/>
+
+            </intracellularProperties>
+
+        </biophysicalProperties>
+
+    </cell>
+
+    <pulseGenerator id="IClamp" delay="500ms" duration="50ms" amplitude="0.1 nA" />
+
+    <network id="net1" type="networkWithTemperature" temperature = "34 degC">
+        <population id="pop" component="hh" size="1"/>
+        <explicitInput target="pop[0]" input="IClamp" destination="synapses"/>
+    </network>
+    
+
+    <Simulation id="sim1" length="1000ms" step="0.01ms" target="net1">
+    
+        <Display id="d1" title="Voltage" timeScale="1ms" xmin="0" xmax="1000" ymin="-90" ymax="60">
+            <Line id="v" quantity="pop[0]/v" scale="1mV"  color="#ffffff" timeScale="1ms"/>
+        </Display>
+        
+        <Display id="d2" title="K chanell: rate variables" timeScale="1ms" xmin="0" xmax="1000" ymin="-0.1" ymax="1.1">
+            <Line id="k_slow_a" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/a/q" scale="1"  color="#0000ff" timeScale="1ms"/>
+            <Line id="k_slow_b_bb" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/b/bb/q" scale="1"  color="#00bbb00" timeScale="1ms"/>
+            <Line id="k_slow_b_bb1" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/b/bb1/q" scale="1"  color="#bb0000" timeScale="1ms"/>
+        </Display>
+    
+        <Display id="d3" title="current" timeScale="1ms" xmin="0" xmax="1000" ymin="-0.01" ymax="1">
+            <Line id="i" quantity="pop[0]/IClamp/i" scale="1nA"  color="#000000" timeScale="1ms"/>
+        </Display>
+
+        <Display id="d4" title="potassium fractional conductance: a^2(0.5*bb + 0.5*bb1)" timeScale="1ms" xmin="0" xmax="1000" ymin="-0.1" ymax="1.1">
+            <Line id="k_slow_b_fcond" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/b/fcond" scale="1"  color="#0000ff" timeScale="1ms"/>
+            <Line id="k_slow_fopen" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/fopen" scale="1"  color="#0000ff" timeScale="1ms"/>
+        </Display>
+    
+        <OutputFile id="of0" fileName="results/hh_v.dat">
+            <OutputColumn id="v" quantity="pop[0]/v"/> 
+            <OutputColumn id="kslow_fcond" quantity="pop[0]/biophys/membraneProperties/k_slowChans/k_slow/fopen"/> 
+        </OutputFile>  
+    
+    </Simulation>
+    
+
+
+
+</Lems>

--- a/NeuroML2CoreTypes/Channels.xml
+++ b/NeuroML2CoreTypes/Channels.xml
@@ -449,6 +449,51 @@
     </ComponentType>
 
 
+    <ComponentType name="gateFractional"
+                   extends="baseGate"
+                   description="Gate composed of subgates contributing with fractional conductance">
+
+        <Children name="q10Settings" type="baseQ10Settings"/>
+        <Children name="subGate" type="subGate"/>
+        <Exposure name="rateScale" dimension="none"/>
+
+        <Dynamics>
+            <DerivedVariable name="q" exposure="q" dimension="none" select="subGate[*]/qfrac" reduce="add"/>
+            <DerivedVariable name="fcond" exposure="fcond" dimension="none" value="q^instances"/>
+            <DerivedVariable name="rateScale" exposure="rateScale" dimension="none" select="q10Settings[*]/q10" reduce="multiply"/>
+        </Dynamics>
+    </ComponentType>
+
+
+    <ComponentType name="subGate"
+                   description="Gate composed of subgates contributing with fractional conductance">
+
+        <Child name="notes" type="notes"/>
+
+        <Child name="timeCourse" type="baseVoltageDepTime" />
+        <Child name="steadyState" type="baseVoltageDepVariable" />
+        <Parameter name="fractionalConductance" dimension="none"/>
+
+        <Exposure name="tau" dimension="time"/>
+        <Exposure name="inf" dimension="none"/>
+        <Exposure name="qfrac" dimension="none"/>
+        <Exposure name="q" dimension="none"/>
+        <Requirement name="rateScale" dimension="none"/>
+
+        <Dynamics>
+            <StateVariable name="q" exposure="q" dimension="none"/>
+            <DerivedVariable name="inf" dimension="none" exposure="inf" select="steadyState/x"/>
+            <DerivedVariable name="tauUnscaled" dimension="time" select="timeCourse/t"/>
+            <DerivedVariable name="tau" dimension="time" exposure="tau" value="tauUnscaled / rateScale"/>
+            <DerivedVariable name="qfrac" dimension="none" exposure="qfrac" value="q * fractionalConductance"/>
+            <TimeDerivative variable="q" value="(inf - q) / tau"/>
+            <OnStart>
+                <StateAssignment variable="q" value="inf"/>
+            </OnStart>
+        </Dynamics>
+    </ComponentType>
+
+
     <ComponentType name="baseIonChannel"
                    description="Base for all ion channel ComponentTypes">
         <Parameter name="conductance" dimension="conductance"/>
@@ -486,6 +531,7 @@
         <Children name="gatesHHratesInf" type="gateHHratesInf"/>
         <Children name="gatesHHratesTauInf" type="gateHHratesTauInf"/>
         <Children name="gateHHInstantaneous" type="gateHHInstantaneous"/>
+        <Children name="gatesFractional" type="gateFractional"/>
         
         <Text name="neuroLexId"/>
         <Text name="species"/>
@@ -498,7 +544,8 @@
             <DerivedVariable name="fopenHHratesInf" dimension="none" select="gatesHHratesInf[*]/fcond" reduce="multiply"/>
             <DerivedVariable name="fopenHHratesTauInf" dimension="none" select="gatesHHratesTauInf[*]/fcond" reduce="multiply"/>
             <DerivedVariable name="fopenHHInstantaneous" dimension="none" select="gateHHInstantaneous[*]/fcond" reduce="multiply"/>
-            <DerivedVariable name="fopen" exposure="fopen" dimension="none" value="conductanceScale * fopenHHrates * fopenHHtauInf * fopenHHratesTau * fopenHHratesInf * fopenHHratesTauInf * fopenHHInstantaneous"/>
+            <DerivedVariable name="fopenFractional" dimension="none" select="gatesFractional[*]/fcond" reduce="multiply"/>
+            <DerivedVariable name="fopen" exposure="fopen" dimension="none" value="conductanceScale * fopenHHrates * fopenHHtauInf * fopenHHratesTau * fopenHHratesInf * fopenHHratesTauInf * fopenHHInstantaneous * fopenFractional"/>
             <DerivedVariable name="g" exposure="g" value="conductance * fopen" dimension="conductance"/>
         </Dynamics>
     </ComponentType>
@@ -658,10 +705,10 @@
     
         <Dynamics>
 
+            <DerivedVariable name="rateScale" exposure="rateScale" dimension="none" select="q10Settings[*]/q10" reduce="multiply"/>
             <DerivedVariable name="q" exposure="q" dimension="none" select="states[*]/q" reduce="add"/>
             <DerivedVariable name="fcond" exposure="fcond" dimension="none" value="q^instances"/>
             
-            <DerivedVariable name="rateScale" exposure="rateScale" dimension="none" select="q10Settings[*]/q10" reduce="multiply"/>
 
             <KineticScheme name="ks" nodes="states" stateVariable="occupancy"
                            edges="transitions" edgeSource="from" edgeTarget="to"

--- a/Schemas/NeuroML2/NeuroML_v2beta4.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2beta4.xsd
@@ -683,6 +683,7 @@
             <xs:enumeration value="gateHHratesTauInf"/>
             <xs:enumeration value="gateHHInstantaneous"/>
             <xs:enumeration value="gateKS"/>
+            <xs:enumeration value="gateFractional"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -879,6 +880,35 @@
                 </xs:all>
                 <xs:attribute name="instances" type="PositiveInteger" use="required"/>
                 <!-- <xs:attribute name="type" type="gateTypes" use="optional"/> No longer allowed as it could conflict with the element definition -->
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+
+    <xs:complexType name="GateFractional">
+        <xs:complexContent>
+            <xs:extension base="Base">
+                <xs:all>
+                    <xs:element name="notes" type="Notes" minOccurs="0"/>
+                    <xs:element name="q10Settings" type="Q10Settings" minOccurs="0"/>
+                    <xs:element name="subGate" type="GateFractionalSubgate" minOccurs="1"/>
+                </xs:all>
+                <xs:attribute name="fractionalConductance" type="Nml2Quantity_none" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+
+    <xs:complexType name="GateFractionalSubgate">
+        <xs:complexContent>
+            <xs:extension base="Base">
+                <xs:all>
+                    <xs:element name="notes" type="Notes" minOccurs="0"/>
+                    <xs:element name="q10Settings" type="Q10Settings" minOccurs="0"/>
+                    <xs:element name="steadyState" type="HHVariable" minOccurs="1"/>
+                    <xs:element name="timeCourse" type="HHTime" minOccurs="1"/>
+                </xs:all>
+                <xs:attribute name="fractionalConductance" type="Nml2Quantity_none" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>


### PR DESCRIPTION
Added new gate type allowing for fractional conductance channels to be more concisely described:
```xml
<gateFractional id="b" instances="1">
    <subGate fractionalConductance="0.5" id="bb">
        <steadyState type="HHSigmoidVariable" rate="1" midpoint="-58mV" scale="-11mV"/>
        <timeCourse type="kslow_b_tau"/>
    </subGate>
    <subGate fractionalConductance="0.5" id="bb1">
        <steadyState type="HHSigmoidVariable" rate="1" midpoint="-58mV" scale="-11mV"/>
        <timeCourse type="kslow_b1_tau"/>
    </subGate>
</gateFractional>
```