### PR TITLE
fix(generate.py): use Decimal to correctly report conversion factors

### DIFF
--- a/docs/NeuroMLCoreDimensions.html
+++ b/docs/NeuroMLCoreDimensions.html
@@ -505,7 +505,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1000000.0 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 999999999.9999999 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1000000000000.0 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+6 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+9 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+12 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="A_per_m2">&nbsp;</a>
@@ -518,7 +518,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 100.0 <a href='#uA_per_cm2'>uA_per_cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 0.1 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 1.0E+2 <a href='#uA_per_cm2'>uA_per_cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 0.1 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="C">&nbsp;</a>
@@ -544,7 +544,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#charge_per_mole">charge_per_mole</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 C_per_mol = 1e-06 <a href='#nA_ms_per_amol'>nA_ms_per_amol</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 C_per_mol = 0.000001 <a href='#nA_ms_per_amol'>nA_ms_per_amol</a>    </td>
   </tr>
 </table>
 <a name="F">&nbsp;</a>
@@ -557,7 +557,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1000000.0 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 999999999.9999999 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1000000000000.0 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+6 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+9 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+12 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="F_per_m2">&nbsp;</a>
@@ -570,7 +570,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#specificCapacitance">specificCapacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F_per_m2 = 100.0 <a href='#uF_per_cm2'>uF_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F_per_m2 = 1.0E+2 <a href='#uF_per_cm2'>uF_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="Hz">&nbsp;</a>
@@ -583,7 +583,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 1.0 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 59.999999988 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 3599.9999999712 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 1 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 3.6E+3 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="J_per_K_per_mol">&nbsp;</a>
@@ -609,7 +609,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#temperature">temperature</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 K = 0.0036476381542950944 <a href='#degC'>degC</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 K = 0.0036 <a href='#degC'>degC</a>    </td>
   </tr>
 </table>
 <a name="M">&nbsp;</a>
@@ -622,7 +622,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1000.0 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 0.001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1000.0 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1.0E+3 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 0.001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1.0E+3 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="Mohm">&nbsp;</a>
@@ -635,7 +635,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1000000.0 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1000.0 <a href='#kohm'>kohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1.0E+6 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1.0E+3 <a href='#kohm'>kohm</a>    </td>
   </tr>
 </table>
 <a name="S">&nbsp;</a>
@@ -648,7 +648,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1000.0 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1000000.0 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 999999999.9999999 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1000000000000.0 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+3 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+6 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+9 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+12 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="S_per_V">&nbsp;</a>
@@ -661,7 +661,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance_per_voltage">conductance_per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_V = 1000000.0 <a href='#nS_per_mV'>nS_per_mV</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_V = 1.0E+6 <a href='#nS_per_mV'>nS_per_mV</a>    </td>
   </tr>
 </table>
 <a name="S_per_cm2">&nbsp;</a>
@@ -674,7 +674,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductanceDensity">conductanceDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 4<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 10000.0 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1000.0 <a href='#mS_per_cm2'>mS_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1.0E+4 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1.0E+3 <a href='#mS_per_cm2'>mS_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="S_per_m2">&nbsp;</a>
@@ -700,7 +700,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#voltage">voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 V = 1000.0 <a href='#mV'>mV</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 V = 1.0E+3 <a href='#mV'>mV</a>    </td>
   </tr>
 </table>
 <a name="cm">&nbsp;</a>
@@ -713,7 +713,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 0.01 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 10000.0 <a href='#um'>um</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 0.010 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 1.0E+4 <a href='#um'>um</a>    </td>
   </tr>
 </table>
 <a name="cm2">&nbsp;</a>
@@ -726,7 +726,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -4<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 0.0001 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 100000000.0 <a href='#um2'>um2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 0.00010 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 1.0E+8 <a href='#um2'>um2</a>    </td>
   </tr>
 </table>
 <a name="cm3">&nbsp;</a>
@@ -739,7 +739,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 1e-06 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.001 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 999999999999.9999 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.0000010 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.0010 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 1.0E+12 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="cm_per_ms">&nbsp;</a>
@@ -752,7 +752,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10.0 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1000.0 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10000.0 <a href='#um_per_ms'>um_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1.0E+3 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1.0E+4 <a href='#um_per_ms'>um_per_ms</a>    </td>
   </tr>
 </table>
 <a name="cm_per_s">&nbsp;</a>
@@ -765,7 +765,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.01 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 10.0 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.001 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.010 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 1E+1 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.0010 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 <a name="degC">&nbsp;</a>
@@ -778,7 +778,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#temperature">temperature</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Offset: 273.15<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 degC = 274.15 <a href='#K'>K</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 degC = 2.7E+2 <a href='#K'>K</a>    </td>
   </tr>
 </table>
 <a name="hour">&nbsp;</a>
@@ -791,7 +791,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 3600.0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3600.0 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3600000.0 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 60.0 <a href='#min'>min</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3.6E+3 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3.6E+6 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 60 <a href='#min'>min</a>    </td>
   </tr>
 </table>
 <a name="kohm">&nbsp;</a>
@@ -804,7 +804,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 1000.0 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 0.001 <a href='#Mohm'>Mohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 1.0E+3 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 0.001 <a href='#Mohm'>Mohm</a>    </td>
   </tr>
 </table>
 <a name="kohm_cm">&nbsp;</a>
@@ -817,7 +817,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 10.0 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 1000.0 <a href='#ohm_cm'>ohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 10 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 1.0E+3 <a href='#ohm_cm'>ohm_cm</a>    </td>
   </tr>
 </table>
 <a name="litre">&nbsp;</a>
@@ -830,7 +830,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 0.001 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1000.0000000000001 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1000000000000000.0 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 0.0010 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1.0E+3 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1.0E+15 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="m">&nbsp;</a>
@@ -843,7 +843,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 100.0 <a href='#cm'>cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1000000.0 <a href='#um'>um</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1.0E+2 <a href='#cm'>cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1.0E+6 <a href='#um'>um</a>    </td>
   </tr>
 </table>
 <a name="m2">&nbsp;</a>
@@ -856,7 +856,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 10000.0 <a href='#cm2'>cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1000000000000.0 <a href='#um2'>um2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1.0E+4 <a href='#cm2'>cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1.0E+12 <a href='#um2'>um2</a>    </td>
   </tr>
 </table>
 <a name="m3">&nbsp;</a>
@@ -869,7 +869,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1000000.0 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1000.0 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 9.999999999999999e+17 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+6 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+3 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+18 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="mA_per_cm2">&nbsp;</a>
@@ -882,7 +882,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 10.0 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 1000.0 <a href='#uA_per_cm2'>uA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 10 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 1.0E+3 <a href='#uA_per_cm2'>uA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="mM">&nbsp;</a>
@@ -895,7 +895,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1.0 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1e-06 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.001 <a href='#M'>M</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.000001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.001 <a href='#M'>M</a>    </td>
   </tr>
 </table>
 <a name="mS">&nbsp;</a>
@@ -908,7 +908,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 0.001 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1000.0000000000001 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1000000.0 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1000000000.0 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 0.0010 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+3 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+6 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+9 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="mS_per_cm2">&nbsp;</a>
@@ -921,7 +921,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductanceDensity">conductanceDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS_per_cm2 = 10.0 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS_per_cm2 = 0.001 <a href='#S_per_cm2'>S_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS_per_cm2 = 10 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS_per_cm2 = 0.001 <a href='#S_per_cm2'>S_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="mV">&nbsp;</a>
@@ -934,7 +934,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#voltage">voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mV = 0.001 <a href='#V'>V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mV = 0.0010 <a href='#V'>V</a>    </td>
   </tr>
 </table>
 <a name="m_per_s">&nbsp;</a>
@@ -947,7 +947,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 100.0 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1000.0 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 0.1 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1.0E+2 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1.0E+3 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 0.1 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 <a name="min">&nbsp;</a>
@@ -960,7 +960,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 60.0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 60.0 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 60000.0 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 0.016666666666666666 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 60 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 6.0E+4 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 0.017 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="mol">&nbsp;</a>
@@ -986,7 +986,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1000000.0 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1000.0 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1000000.0 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+6 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+3 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+6 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="mol_per_cm_per_uA_per_ms">&nbsp;</a>
@@ -999,7 +999,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#rho_factor">rho_factor</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 11<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm_per_uA_per_ms = 100000000000.0 <a href='#mol_per_m_per_A_per_s'>mol_per_m_per_A_per_s</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm_per_uA_per_ms = 1.0E+11 <a href='#mol_per_m_per_A_per_s'>mol_per_m_per_A_per_s</a>    </td>
   </tr>
 </table>
 <a name="mol_per_m3">&nbsp;</a>
@@ -1012,7 +1012,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1e-06 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.001 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1.0 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.000001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.001 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="mol_per_m_per_A_per_s">&nbsp;</a>
@@ -1025,7 +1025,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#rho_factor">rho_factor</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m_per_A_per_s = 1e-11 <a href='#mol_per_cm_per_uA_per_ms'>mol_per_cm_per_uA_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m_per_A_per_s = 1E-11 <a href='#mol_per_cm_per_uA_per_ms'>mol_per_cm_per_uA_per_ms</a>    </td>
   </tr>
 </table>
 <a name="ms">&nbsp;</a>
@@ -1038,7 +1038,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.001 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 1.6666666666666667e-05 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 2.7777777777777776e-07 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.0010 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.000017 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 2.8E-7 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="nA">&nbsp;</a>
@@ -1051,7 +1051,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1e-09 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 0.001 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1000.0000000000001 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1.0E-9 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 0.0010 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1.0E+3 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="nA_ms_per_amol">&nbsp;</a>
@@ -1064,7 +1064,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#charge_per_mole">charge_per_mole</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA_ms_per_amol = 1000000.0 <a href='#C_per_mol'>C_per_mol</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA_ms_per_amol = 1.0E+6 <a href='#C_per_mol'>C_per_mol</a>    </td>
   </tr>
 </table>
 <a name="nF">&nbsp;</a>
@@ -1077,7 +1077,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1e-09 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 0.001 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1000.0000000000001 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1.0E-9 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 0.0010 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1.0E+3 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="nS">&nbsp;</a>
@@ -1090,7 +1090,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1e-09 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1e-06 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.001 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1000.0000000000001 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1.0E-9 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.0000010 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.0010 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1.0E+3 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="nS_per_mV">&nbsp;</a>
@@ -1103,7 +1103,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance_per_voltage">conductance_per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS_per_mV = 1e-06 <a href='#S_per_V'>S_per_V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS_per_mV = 0.0000010 <a href='#S_per_V'>S_per_V</a>    </td>
   </tr>
 </table>
 <a name="ohm">&nbsp;</a>
@@ -1116,7 +1116,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.001 <a href='#kohm'>kohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 1e-06 <a href='#Mohm'>Mohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.001 <a href='#kohm'>kohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.000001 <a href='#Mohm'>Mohm</a>    </td>
   </tr>
 </table>
 <a name="ohm_cm">&nbsp;</a>
@@ -1129,7 +1129,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.01 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.001 <a href='#kohm_cm'>kohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.010 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.0010 <a href='#kohm_cm'>kohm_cm</a>    </td>
   </tr>
 </table>
 <a name="ohm_m">&nbsp;</a>
@@ -1142,7 +1142,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 0.1 <a href='#kohm_cm'>kohm_cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 100.0 <a href='#ohm_cm'>ohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 0.1 <a href='#kohm_cm'>kohm_cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 1.0E+2 <a href='#ohm_cm'>ohm_cm</a>    </td>
   </tr>
 </table>
 <a name="pA">&nbsp;</a>
@@ -1155,7 +1155,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1e-12 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1e-06 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.001 <a href='#nA'>nA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1.0E-12 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.0000010 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.0010 <a href='#nA'>nA</a>    </td>
   </tr>
 </table>
 <a name="pF">&nbsp;</a>
@@ -1168,7 +1168,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1e-12 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1e-06 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.001 <a href='#nF'>nF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1.0E-12 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.0000010 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.0010 <a href='#nF'>nF</a>    </td>
   </tr>
 </table>
 <a name="pS">&nbsp;</a>
@@ -1181,7 +1181,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-12 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-09 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-06 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.001 <a href='#nS'>nS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1.0E-12 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1.0E-9 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.0000010 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.0010 <a href='#nS'>nS</a>    </td>
   </tr>
 </table>
 <a name="per_V">&nbsp;</a>
@@ -1207,7 +1207,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 0.00027777777778<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00027777777778 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00027777777778 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 2.7777777778e-07 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.016666666663466667 <a href='#per_min'>per_min</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00028 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00028 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 2.8E-7 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.017 <a href='#per_min'>per_min</a>    </td>
   </tr>
 </table>
 <a name="per_mV">&nbsp;</a>
@@ -1220,7 +1220,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_voltage">per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_mV = 1000.0 <a href='#per_V'>per_V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_mV = 1.0E+3 <a href='#per_V'>per_V</a>    </td>
   </tr>
 </table>
 <a name="per_min">&nbsp;</a>
@@ -1233,7 +1233,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 0.01666666667<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.01666666667 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.01666666667 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 1.666666667e-05 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 60.00000001152 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.017 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.017 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.000017 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 60 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="per_ms">&nbsp;</a>
@@ -1246,7 +1246,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1000.0 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1000.0 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 59999.999988 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 3599999.9999712 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1.0E+3 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1.0E+3 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 6.0E+4 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 3.6E+6 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="per_s">&nbsp;</a>
@@ -1259,7 +1259,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 1.0 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 59.999999988 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 3599.9999999712 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 1 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 3.6E+3 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="s">&nbsp;</a>
@@ -1272,7 +1272,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 1000.0 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.016666666666666666 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.0002777777777777778 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 1.0E+3 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.017 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.00028 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="uA">&nbsp;</a>
@@ -1285,7 +1285,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1e-06 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 999.9999999999999 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1000000.0 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 0.0000010 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1.0E+3 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1.0E+6 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="uA_per_cm2">&nbsp;</a>
@@ -1298,7 +1298,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.01 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.001 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.010 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.0010 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="uF">&nbsp;</a>
@@ -1311,7 +1311,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1e-06 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 999.9999999999999 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1000000.0 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 0.0000010 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1.0E+3 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1.0E+6 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="uF_per_cm2">&nbsp;</a>
@@ -1324,7 +1324,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#specificCapacitance">specificCapacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF_per_cm2 = 0.01 <a href='#F_per_m2'>F_per_m2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF_per_cm2 = 0.010 <a href='#F_per_m2'>F_per_m2</a>    </td>
   </tr>
 </table>
 <a name="uS">&nbsp;</a>
@@ -1337,7 +1337,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1e-06 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.001 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 999.9999999999999 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1000000.0 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.0000010 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.0010 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1.0E+3 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1.0E+6 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="um">&nbsp;</a>
@@ -1350,7 +1350,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 1e-06 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 9.999999999999999e-05 <a href='#cm'>cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 0.0000010 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 0.00010 <a href='#cm'>cm</a>    </td>
   </tr>
 </table>
 <a name="um2">&nbsp;</a>
@@ -1363,7 +1363,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1e-12 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 9.999999999999999e-09 <a href='#cm2'>cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1.0E-12 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1.0E-8 <a href='#cm2'>cm2</a>    </td>
   </tr>
 </table>
 <a name="um3">&nbsp;</a>
@@ -1376,7 +1376,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -18<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1e-18 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0000000000000002e-12 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1e-15 <a href='#litre'>litre</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-18 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-12 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-15 <a href='#litre'>litre</a>    </td>
   </tr>
 </table>
 <a name="um_per_ms">&nbsp;</a>
@@ -1389,7 +1389,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.001 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.1 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.0001 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.0010 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.1 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.00010 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 </div>

--- a/docs/NeuroMLCoreDimensions.html
+++ b/docs/NeuroMLCoreDimensions.html
@@ -505,7 +505,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+6 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+9 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.0E+12 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.00e+06 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.00e+09 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A = 1.00e+12 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="A_per_m2">&nbsp;</a>
@@ -518,7 +518,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 1.0E+2 <a href='#uA_per_cm2'>uA_per_cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 0.1 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 100 <a href='#uA_per_cm2'>uA_per_cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 A_per_m2 = 0.1 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="C">&nbsp;</a>
@@ -544,7 +544,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#charge_per_mole">charge_per_mole</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 C_per_mol = 0.000001 <a href='#nA_ms_per_amol'>nA_ms_per_amol</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 C_per_mol = 1e-06 <a href='#nA_ms_per_amol'>nA_ms_per_amol</a>    </td>
   </tr>
 </table>
 <a name="F">&nbsp;</a>
@@ -557,7 +557,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+6 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+9 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.0E+12 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.00e+06 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.00e+09 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F = 1.00e+12 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="F_per_m2">&nbsp;</a>
@@ -570,7 +570,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#specificCapacitance">specificCapacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F_per_m2 = 1.0E+2 <a href='#uF_per_cm2'>uF_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 F_per_m2 = 100 <a href='#uF_per_cm2'>uF_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="Hz">&nbsp;</a>
@@ -583,7 +583,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 1 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 3.6E+3 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 1 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Hz = 3600 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="J_per_K_per_mol">&nbsp;</a>
@@ -609,7 +609,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#temperature">temperature</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 K = 0.0036 <a href='#degC'>degC</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 K = 0.0036476 <a href='#degC'>degC</a>    </td>
   </tr>
 </table>
 <a name="M">&nbsp;</a>
@@ -622,7 +622,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1.0E+3 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 0.001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1.0E+3 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1000 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 0.001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 M = 1000 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="Mohm">&nbsp;</a>
@@ -635,7 +635,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1.0E+6 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1.0E+3 <a href='#kohm'>kohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1.00e+06 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 Mohm = 1000 <a href='#kohm'>kohm</a>    </td>
   </tr>
 </table>
 <a name="S">&nbsp;</a>
@@ -648,7 +648,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+3 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+6 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+9 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.0E+12 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1000 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.00e+06 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.00e+09 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S = 1.00e+12 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="S_per_V">&nbsp;</a>
@@ -661,7 +661,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance_per_voltage">conductance_per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_V = 1.0E+6 <a href='#nS_per_mV'>nS_per_mV</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_V = 1.00e+06 <a href='#nS_per_mV'>nS_per_mV</a>    </td>
   </tr>
 </table>
 <a name="S_per_cm2">&nbsp;</a>
@@ -674,7 +674,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductanceDensity">conductanceDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 4<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1.0E+4 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1.0E+3 <a href='#mS_per_cm2'>mS_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 10000 <a href='#S_per_m2'>S_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 S_per_cm2 = 1000 <a href='#mS_per_cm2'>mS_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="S_per_m2">&nbsp;</a>
@@ -700,7 +700,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#voltage">voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 V = 1.0E+3 <a href='#mV'>mV</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 V = 1000 <a href='#mV'>mV</a>    </td>
   </tr>
 </table>
 <a name="cm">&nbsp;</a>
@@ -713,7 +713,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 0.010 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 1.0E+4 <a href='#um'>um</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 0.01 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm = 10000 <a href='#um'>um</a>    </td>
   </tr>
 </table>
 <a name="cm2">&nbsp;</a>
@@ -726,7 +726,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -4<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 0.00010 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 1.0E+8 <a href='#um2'>um2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 0.0001 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm2 = 1.00e+08 <a href='#um2'>um2</a>    </td>
   </tr>
 </table>
 <a name="cm3">&nbsp;</a>
@@ -739,7 +739,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.0000010 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.0010 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 1.0E+12 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 1e-06 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 0.001 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm3 = 1.00e+12 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="cm_per_ms">&nbsp;</a>
@@ -752,7 +752,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1.0E+3 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1.0E+4 <a href='#um_per_ms'>um_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 1000 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_ms = 10000 <a href='#um_per_ms'>um_per_ms</a>    </td>
   </tr>
 </table>
 <a name="cm_per_s">&nbsp;</a>
@@ -765,7 +765,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.010 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 1E+1 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.0010 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.01 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 10 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 cm_per_s = 0.001 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 <a name="degC">&nbsp;</a>
@@ -778,7 +778,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#temperature">temperature</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Offset: 273.15<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 degC = 2.7E+2 <a href='#K'>K</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 degC = 274.15 <a href='#K'>K</a>    </td>
   </tr>
 </table>
 <a name="hour">&nbsp;</a>
@@ -791,7 +791,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 3600.0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3.6E+3 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3.6E+6 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 60 <a href='#min'>min</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3600 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 3.60e+06 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 hour = 60 <a href='#min'>min</a>    </td>
   </tr>
 </table>
 <a name="kohm">&nbsp;</a>
@@ -804,7 +804,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 1.0E+3 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 0.001 <a href='#Mohm'>Mohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 1000 <a href='#ohm'>ohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm = 0.001 <a href='#Mohm'>Mohm</a>    </td>
   </tr>
 </table>
 <a name="kohm_cm">&nbsp;</a>
@@ -817,7 +817,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 10 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 1.0E+3 <a href='#ohm_cm'>ohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 10 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 kohm_cm = 1000 <a href='#ohm_cm'>ohm_cm</a>    </td>
   </tr>
 </table>
 <a name="litre">&nbsp;</a>
@@ -830,7 +830,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 0.0010 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1.0E+3 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1.0E+15 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 0.001 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1000 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 litre = 1.00e+15 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="m">&nbsp;</a>
@@ -843,7 +843,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1.0E+2 <a href='#cm'>cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1.0E+6 <a href='#um'>um</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 100 <a href='#cm'>cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m = 1.00e+06 <a href='#um'>um</a>    </td>
   </tr>
 </table>
 <a name="m2">&nbsp;</a>
@@ -856,7 +856,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1.0E+4 <a href='#cm2'>cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1.0E+12 <a href='#um2'>um2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 10000 <a href='#cm2'>cm2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m2 = 1.00e+12 <a href='#um2'>um2</a>    </td>
   </tr>
 </table>
 <a name="m3">&nbsp;</a>
@@ -869,7 +869,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+6 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+3 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.0E+18 <a href='#um3'>um3</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.00e+06 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1000 <a href='#litre'>litre</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m3 = 1.00e+18 <a href='#um3'>um3</a>    </td>
   </tr>
 </table>
 <a name="mA_per_cm2">&nbsp;</a>
@@ -882,7 +882,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 1<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 10 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 1.0E+3 <a href='#uA_per_cm2'>uA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 10 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mA_per_cm2 = 1000 <a href='#uA_per_cm2'>uA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="mM">&nbsp;</a>
@@ -895,7 +895,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.000001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.001 <a href='#M'>M</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 1e-06 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mM = 0.001 <a href='#M'>M</a>    </td>
   </tr>
 </table>
 <a name="mS">&nbsp;</a>
@@ -908,7 +908,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 0.0010 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+3 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+6 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.0E+9 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 0.001 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1000 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.00e+06 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mS = 1.00e+09 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="mS_per_cm2">&nbsp;</a>
@@ -934,7 +934,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#voltage">voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mV = 0.0010 <a href='#V'>V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mV = 0.001 <a href='#V'>V</a>    </td>
   </tr>
 </table>
 <a name="m_per_s">&nbsp;</a>
@@ -947,7 +947,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1.0E+2 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1.0E+3 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 0.1 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 100 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 1000 <a href='#um_per_ms'>um_per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 m_per_s = 0.1 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 <a name="min">&nbsp;</a>
@@ -960,7 +960,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 60.0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 60 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 6.0E+4 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 0.017 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 60 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 6.00e+04 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 min = 0.016667 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="mol">&nbsp;</a>
@@ -986,7 +986,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+6 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+3 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.0E+6 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.00e+06 <a href='#mol_per_m3'>mol_per_m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1000 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm3 = 1.00e+06 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="mol_per_cm_per_uA_per_ms">&nbsp;</a>
@@ -999,7 +999,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#rho_factor">rho_factor</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 11<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm_per_uA_per_ms = 1.0E+11 <a href='#mol_per_m_per_A_per_s'>mol_per_m_per_A_per_s</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_cm_per_uA_per_ms = 1.00e+11 <a href='#mol_per_m_per_A_per_s'>mol_per_m_per_A_per_s</a>    </td>
   </tr>
 </table>
 <a name="mol_per_m3">&nbsp;</a>
@@ -1012,7 +1012,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#concentration">concentration</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.000001 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.001 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1 <a href='#mM'>mM</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1e-06 <a href='#mol_per_cm3'>mol_per_cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 0.001 <a href='#M'>M</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m3 = 1 <a href='#mM'>mM</a>    </td>
   </tr>
 </table>
 <a name="mol_per_m_per_A_per_s">&nbsp;</a>
@@ -1025,7 +1025,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#rho_factor">rho_factor</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m_per_A_per_s = 1E-11 <a href='#mol_per_cm_per_uA_per_ms'>mol_per_cm_per_uA_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 mol_per_m_per_A_per_s = 1e-11 <a href='#mol_per_cm_per_uA_per_ms'>mol_per_cm_per_uA_per_ms</a>    </td>
   </tr>
 </table>
 <a name="ms">&nbsp;</a>
@@ -1038,7 +1038,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.0010 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.000017 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 2.8E-7 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 0.001 <a href='#s'>s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 1.6667e-05 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ms = 2.7778e-07 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="nA">&nbsp;</a>
@@ -1051,7 +1051,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1.0E-9 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 0.0010 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1.0E+3 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1e-09 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 0.001 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA = 1000 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="nA_ms_per_amol">&nbsp;</a>
@@ -1064,7 +1064,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#charge_per_mole">charge_per_mole</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA_ms_per_amol = 1.0E+6 <a href='#C_per_mol'>C_per_mol</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nA_ms_per_amol = 1.00e+06 <a href='#C_per_mol'>C_per_mol</a>    </td>
   </tr>
 </table>
 <a name="nF">&nbsp;</a>
@@ -1077,7 +1077,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1.0E-9 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 0.0010 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1.0E+3 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1e-09 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 0.001 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nF = 1000 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="nS">&nbsp;</a>
@@ -1090,7 +1090,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -9<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1.0E-9 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.0000010 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.0010 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1.0E+3 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1e-09 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1e-06 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 0.001 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS = 1000 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="nS_per_mV">&nbsp;</a>
@@ -1103,7 +1103,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance_per_voltage">conductance_per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS_per_mV = 0.0000010 <a href='#S_per_V'>S_per_V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 nS_per_mV = 1e-06 <a href='#S_per_V'>S_per_V</a>    </td>
   </tr>
 </table>
 <a name="ohm">&nbsp;</a>
@@ -1116,7 +1116,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistance">resistance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.001 <a href='#kohm'>kohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.000001 <a href='#Mohm'>Mohm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 0.001 <a href='#kohm'>kohm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm = 1e-06 <a href='#Mohm'>Mohm</a>    </td>
   </tr>
 </table>
 <a name="ohm_cm">&nbsp;</a>
@@ -1129,7 +1129,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.010 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.0010 <a href='#kohm_cm'>kohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.01 <a href='#ohm_m'>ohm_m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_cm = 0.001 <a href='#kohm_cm'>kohm_cm</a>    </td>
   </tr>
 </table>
 <a name="ohm_m">&nbsp;</a>
@@ -1142,7 +1142,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#resistivity">resistivity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 0.1 <a href='#kohm_cm'>kohm_cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 1.0E+2 <a href='#ohm_cm'>ohm_cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 0.1 <a href='#kohm_cm'>kohm_cm</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 ohm_m = 100 <a href='#ohm_cm'>ohm_cm</a>    </td>
   </tr>
 </table>
 <a name="pA">&nbsp;</a>
@@ -1155,7 +1155,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1.0E-12 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.0000010 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.0010 <a href='#nA'>nA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1e-12 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 1e-06 <a href='#uA'>uA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pA = 0.001 <a href='#nA'>nA</a>    </td>
   </tr>
 </table>
 <a name="pF">&nbsp;</a>
@@ -1168,7 +1168,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1.0E-12 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.0000010 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.0010 <a href='#nF'>nF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1e-12 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 1e-06 <a href='#uF'>uF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pF = 0.001 <a href='#nF'>nF</a>    </td>
   </tr>
 </table>
 <a name="pS">&nbsp;</a>
@@ -1181,7 +1181,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1.0E-12 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1.0E-9 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.0000010 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.0010 <a href='#nS'>nS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-12 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-09 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 1e-06 <a href='#uS'>uS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 pS = 0.001 <a href='#nS'>nS</a>    </td>
   </tr>
 </table>
 <a name="per_V">&nbsp;</a>
@@ -1207,7 +1207,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 0.00027777777778<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00028 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00028 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 2.8E-7 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.017 <a href='#per_min'>per_min</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00027778 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.00027778 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 2.7778e-07 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_hour = 0.016667 <a href='#per_min'>per_min</a>    </td>
   </tr>
 </table>
 <a name="per_mV">&nbsp;</a>
@@ -1220,7 +1220,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_voltage">per_voltage</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_mV = 1.0E+3 <a href='#per_V'>per_V</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_mV = 1000 <a href='#per_V'>per_V</a>    </td>
   </tr>
 </table>
 <a name="per_min">&nbsp;</a>
@@ -1233,7 +1233,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>&nbsp;&nbsp;&nbsp;&nbsp;Scale: 0.01666666667<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.017 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.017 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.000017 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 60 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.016667 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 0.016667 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 1.6667e-05 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_min = 60 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="per_ms">&nbsp;</a>
@@ -1246,7 +1246,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1.0E+3 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1.0E+3 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 6.0E+4 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 3.6E+6 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1000 <a href='#per_s'>per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 1000 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 6.00e+04 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_ms = 3.60e+06 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="per_s">&nbsp;</a>
@@ -1259,7 +1259,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#per_time">per_time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 1 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 3.6E+3 <a href='#per_hour'>per_hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 1 <a href='#Hz'>Hz</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 0.001 <a href='#per_ms'>per_ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 60 <a href='#per_min'>per_min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 per_s = 3600 <a href='#per_hour'>per_hour</a>    </td>
   </tr>
 </table>
 <a name="s">&nbsp;</a>
@@ -1272,7 +1272,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#time">time</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: 0<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 1.0E+3 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.017 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.00028 <a href='#hour'>hour</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 1000 <a href='#ms'>ms</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.016667 <a href='#min'>min</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 s = 0.00027778 <a href='#hour'>hour</a>    </td>
   </tr>
 </table>
 <a name="uA">&nbsp;</a>
@@ -1285,7 +1285,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#current">current</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 0.0000010 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1.0E+3 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1.0E+6 <a href='#pA'>pA</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1e-06 <a href='#A'>A</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1000 <a href='#nA'>nA</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA = 1.00e+06 <a href='#pA'>pA</a>    </td>
   </tr>
 </table>
 <a name="uA_per_cm2">&nbsp;</a>
@@ -1298,7 +1298,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#currentDensity">currentDensity</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.010 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.0010 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.01 <a href='#A_per_m2'>A_per_m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uA_per_cm2 = 0.001 <a href='#mA_per_cm2'>mA_per_cm2</a>    </td>
   </tr>
 </table>
 <a name="uF">&nbsp;</a>
@@ -1311,7 +1311,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#capacitance">capacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 0.0000010 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1.0E+3 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1.0E+6 <a href='#pF'>pF</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1e-06 <a href='#F'>F</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1000 <a href='#nF'>nF</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF = 1.00e+06 <a href='#pF'>pF</a>    </td>
   </tr>
 </table>
 <a name="uF_per_cm2">&nbsp;</a>
@@ -1324,7 +1324,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#specificCapacitance">specificCapacitance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -2<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF_per_cm2 = 0.010 <a href='#F_per_m2'>F_per_m2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uF_per_cm2 = 0.01 <a href='#F_per_m2'>F_per_m2</a>    </td>
   </tr>
 </table>
 <a name="uS">&nbsp;</a>
@@ -1337,7 +1337,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#conductance">conductance</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.0000010 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.0010 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1.0E+3 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1.0E+6 <a href='#pS'>pS</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1e-06 <a href='#S'>S</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 0.001 <a href='#mS'>mS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1000 <a href='#nS'>nS</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 uS = 1.00e+06 <a href='#pS'>pS</a>    </td>
   </tr>
 </table>
 <a name="um">&nbsp;</a>
@@ -1350,7 +1350,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#length">length</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -6<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 0.0000010 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 0.00010 <a href='#cm'>cm</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 1e-06 <a href='#m'>m</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um = 0.0001 <a href='#cm'>cm</a>    </td>
   </tr>
 </table>
 <a name="um2">&nbsp;</a>
@@ -1363,7 +1363,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#area">area</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -12<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1.0E-12 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1.0E-8 <a href='#cm2'>cm2</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1e-12 <a href='#m2'>m2</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um2 = 1e-08 <a href='#cm2'>cm2</a>    </td>
   </tr>
 </table>
 <a name="um3">&nbsp;</a>
@@ -1376,7 +1376,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#volume">volume</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -18<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-18 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-12 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1.0E-15 <a href='#litre'>litre</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1e-18 <a href='#m3'>m3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1e-12 <a href='#cm3'>cm3</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um3 = 1e-15 <a href='#litre'>litre</a>    </td>
   </tr>
 </table>
 <a name="um_per_ms">&nbsp;</a>
@@ -1389,7 +1389,7 @@ L<sup>3</sup> <br/><br/>&nbsp;&nbsp;&nbsp;&nbsp;Defined unit: <a href='#cm3'>cm3
   <tr>
     <td>
 &nbsp;&nbsp;&nbsp;&nbsp;Dimension: <a href="NeuroMLCoreDimensions.html#permeability">permeability</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;Power of 10: -3<br/>
-<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.0010 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.1 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.00010 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
+<br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.001 <a href='#m_per_s'>m_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.1 <a href='#cm_per_s'>cm_per_s</a><br/>&nbsp;&nbsp;&nbsp;&nbsp;1 um_per_ms = 0.0001 <a href='#cm_per_ms'>cm_per_ms</a>    </td>
   </tr>
 </table>
 </div>

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -21,7 +21,7 @@ from lems.model.dynamics import EventOut
 #
 # References: https://docs.python.org/3/tutorial/floatingpoint.html
 # https://docs.python.org/3/library/decimal.html#module-decimal
-getcontext().prec = 2
+getcontext().prec = 5
 
 nml2_version = "2.1"
 nml2_branch = "master"
@@ -378,7 +378,13 @@ for file in files:
                         factor = 1'''
                     factor1 = model.get_numeric_value("1%s" % unit.symbol, unit.dimension)
                     factor2 = model.get_numeric_value("1%s" % unit2.symbol, unit2.dimension)
-                    contents += "<br/>" + spacer4 + "1 %s = %s <a href='#%s'>%s</a>" % (unit.symbol, "%s" % (Decimal(factor1) / Decimal(factor2)), unit2.symbol, unit2.symbol)
+                    scaled = float(Decimal(factor1) / Decimal(factor2))
+                    if scaled>10000:
+                        scaled = '%.2e'%scaled
+                    else:
+                        scaled = '%s'%scaled
+                    if scaled.endswith('.0'): scaled = scaled[:-2]
+                    contents += "<br/>" + spacer4 + "1 %s = %s <a href='#%s'>%s</a>" % (unit.symbol, "%s" % scaled, unit2.symbol, unit2.symbol)
 
             contents += "    </td>\n"
             contents += "  </tr>\n"

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -3,6 +3,8 @@ A script for generating HTML docs from LEMS descriptions of the core NeuroML 2 C
 """
 
 import textwrap
+from decimal import Decimal
+from decimal import getcontext
 from lems.model.model import Model
 from lems.model.dynamics import OnStart
 from lems.model.dynamics import OnCondition
@@ -11,6 +13,15 @@ from lems.model.dynamics import OnEntry
 from lems.model.dynamics import Transition
 from lems.model.dynamics import StateAssignment
 from lems.model.dynamics import EventOut
+
+# To display correct conversion values, we limit the precision context to 2
+# places (required by Hz). Higher precisions, such as the default machine
+# precision include the usual issues with floating point arithmetic and do not
+# display exact conversions
+#
+# References: https://docs.python.org/3/tutorial/floatingpoint.html
+# https://docs.python.org/3/library/decimal.html#module-decimal
+getcontext().prec = 2
 
 nml2_version = "2.1"
 nml2_branch = "master"
@@ -367,7 +378,7 @@ for file in files:
                         factor = 1'''
                     factor1 = model.get_numeric_value("1%s" % unit.symbol, unit.dimension)
                     factor2 = model.get_numeric_value("1%s" % unit2.symbol, unit2.dimension)
-                    contents += "<br/>" + spacer4 + "1 %s = %s <a href='#%s'>%s</a>" % (unit.symbol, "%s" % (factor1 / factor2), unit2.symbol, unit2.symbol)
+                    contents += "<br/>" + spacer4 + "1 %s = %s <a href='#%s'>%s</a>" % (unit.symbol, "%s" % (Decimal(factor1) / Decimal(factor2)), unit2.symbol, unit2.symbol)
 
             contents += "    </td>\n"
             contents += "  </tr>\n"


### PR DESCRIPTION
To display correct conversion values, we limit the precision context to
2 places (required by Hz). Higher precisions, such as the default
machine precision, include the usual issues with floating point
arithmetic and do not display exact conversions.

References:
- https://docs.python.org/3/tutorial/floatingpoint.html
- https://docs.python.org/3/library/decimal.html#module-decimal

Fixes https://github.com/NeuroML/NeuroML2/issues/134