### PR TITLE
Includes LEMS dynamics elements that are used in the NeuroML core type definitions into the schema

### DIFF
--- a/Schemas/NeuroML2/NeuroML_v2.3.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2.3.xsd
@@ -320,6 +320,7 @@
       <xs:element name="TimeDerivative" type="TimeDerivative" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="OnStart" type="OnStart" minOccurs="0" maxOccurs="1"/>
       <xs:element name="OnEvent" type="OnEvent" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="OnCondition" type="OnCondition" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="DerivedVariable">
@@ -377,6 +378,17 @@
   </xs:complexType>
   <xs:complexType name="EventOut">
       <xs:attribute name="port" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OnCondition">
+    <xs:sequence>
+      <xs:element name="StateAssignment" type="StateAssignment" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="EventOut" type="EventOut" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Transition" type="Transition" minOccurs="0" maxOccurs="1"/>   <!-- only on OnCondition inside Regime... -->
+    </xs:sequence>
+    <xs:attribute name="test" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="Transition">
+    <xs:attribute name="regime" type="xs:string" use="required"/>
   </xs:complexType>
   <xs:simpleType name="ZeroToOne">
     <xs:annotation>

--- a/Schemas/NeuroML2/NeuroML_v2.3.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2.3.xsd
@@ -319,6 +319,7 @@
       <xs:element name="ConditionalDerivedVariable" type="ConditionalDerivedVariable" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="TimeDerivative" type="TimeDerivative" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="OnStart" type="OnStart" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="OnEvent" type="OnEvent" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="DerivedVariable">
@@ -366,6 +367,16 @@
   <xs:complexType name="StateAssignment">
       <xs:attribute name="variable" type="xs:string" use="required"/>
       <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OnEvent">
+      <xs:sequence>
+          <xs:element name="StateAssignment" type="StateAssignment" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="EventOut" type="EventOut" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="port" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="EventOut">
+      <xs:attribute name="port" type="xs:string" use="required"/>
   </xs:complexType>
   <xs:simpleType name="ZeroToOne">
     <xs:annotation>

--- a/Schemas/NeuroML2/NeuroML_v2.3.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2.3.xsd
@@ -321,6 +321,7 @@
       <xs:element name="OnStart" type="OnStart" minOccurs="0" maxOccurs="1"/>
       <xs:element name="OnEvent" type="OnEvent" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="OnCondition" type="OnCondition" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="Regime" type="Regime" minOccurs="0" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="DerivedVariable">
@@ -390,6 +391,26 @@
   <xs:complexType name="Transition">
     <xs:attribute name="regime" type="xs:string" use="required"/>
   </xs:complexType>
+  <xs:complexType name="Regime">
+    <xs:sequence>
+        <xs:element name="TimeDerivative" type="TimeDerivative" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="OnEntry" type="OnEntry" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="OnCondition" type="OnCondition" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+    <xs:attribute name="initial" type="TrueOrFalse" use="optional"/>
+  </xs:complexType>
+  <xs:complexType name="OnEntry">
+    <xs:sequence>
+        <xs:element name="StateAssignment" type="StateAssignment" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="TrueOrFalse">
+    <xs:restriction base="xs:string">
+        <xs:enumeration value="true"/>
+        <xs:enumeration value="false"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="ZeroToOne">
     <xs:annotation>
       <xs:documentation>Float value restricted to between 1 and 0</xs:documentation>

--- a/Schemas/NeuroML2/NeuroML_v2.3.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2.3.xsd
@@ -318,6 +318,7 @@
       <xs:element name="DerivedVariable" type="DerivedVariable" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="ConditionalDerivedVariable" type="ConditionalDerivedVariable" minOccurs="0" maxOccurs="unbounded"/>
       <xs:element name="TimeDerivative" type="TimeDerivative" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="OnStart" type="OnStart" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="DerivedVariable">
@@ -356,6 +357,15 @@
   <xs:complexType name="TimeDerivative">
     <xs:attribute name="variable" type="xs:string" use="required"/>
     <xs:attribute name="value" type="xs:string" use="required"/>
+  </xs:complexType>
+  <xs:complexType name="OnStart">
+    <xs:sequence>
+       <xs:element name="StateAssignment" type="StateAssignment" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="StateAssignment">
+      <xs:attribute name="variable" type="xs:string" use="required"/>
+      <xs:attribute name="value" type="xs:string" use="required"/>
   </xs:complexType>
   <xs:simpleType name="ZeroToOne">
     <xs:annotation>


### PR DESCRIPTION
So that when these are used in new NeuroML ComponentType definitions, the new definitions are also NeuroML schema compliant

Note: did not add Structure bits here.
Note 2: needs bits dependent on the schema to be regenerated, but it shouldn't break anything since we don't remove anything here.