### PR TITLE
feat: make `spikeThresh` required in `membraneProperties`

### DIFF
--- a/Schemas/NeuroML2/NeuroML_v2.3.1.xsd
+++ b/Schemas/NeuroML2/NeuroML_v2.3.1.xsd
@@ -2117,7 +2117,7 @@
           <xs:element name="channelDensityNonUniform" type="ChannelDensityNonUniform" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="channelDensityNonUniformNernst" type="ChannelDensityNonUniformNernst" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="channelDensityNonUniformGHK" type="ChannelDensityNonUniformGHK" minOccurs="0" maxOccurs="unbounded"/>
-          <xs:element name="spikeThresh" type="SpikeThresh" minOccurs="0" maxOccurs="unbounded"/>
+          <xs:element name="spikeThresh" type="SpikeThresh" minOccurs="1" maxOccurs="unbounded"/>
           <xs:element name="specificCapacitance" type="SpecificCapacitance" minOccurs="0" maxOccurs="unbounded"/>
           <xs:element name="initMembPotential" type="InitMembPotential" minOccurs="0" maxOccurs="unbounded"/>
           <!-- Taking this out until confirmation it's needed


### PR DESCRIPTION
fixes #220

TODO: update libNeuroML/NeuroMLC++ and so on.